### PR TITLE
feat: add post install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "prisma generate"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"


### PR DESCRIPTION
This is needed for deploying nextjs applications to Vercel when the application uses Prima. This is because with Vercel, the client generation is not automatically triggered.

More info can be found here: https://www.prisma.io/docs/orm/more/help-and-troubleshooting/vercel-caching-issue